### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload site
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 This project is a small interactive page with three questions. Each question displays an image from this repository. The first image contains clickable hotspots (lotus, log and shore stones) that glow when hovered or clicked. User choices are recorded in JavaScript and shown at the end.
 
 Open `index.html` in your browser to try it out.
+
+## GitHub Pages Workflow
+
+This repository includes a GitHub Actions workflow to deploy the site to
+GitHub Pages. Whenever changes are pushed to the `main` branch, the workflow in
+`.github/workflows/pages.yml` uploads the contents of the repository and
+publishes them as a static site.


### PR DESCRIPTION
## Summary
- enable automatic GitHub Pages deployment via workflow
- mention the workflow in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866d4bd5fb8832ca1753e56238f966d